### PR TITLE
LIBITD-1984. Removed Excel "Read-Only Recommended" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,49 +105,26 @@ This script uses the following sheets in the Google Drive document:
 To run the script (from the project base directory):
 
 ```
-> target/appassembler/bin/all-staff-list-builder --config <CONFIG FILE> [--user <USER>] [--password <PASSWORD>] --input <JSON INPUT FILE> --output <EXCEL OUTPUT FILE>
+> target/appassembler/bin/all-staff-list-builder --config <CONFIG FILE> --input <JSON INPUT FILE> --output <EXCEL OUTPUT FILE>
 ```
 
 where:
 
 * \<CONFIG FILE> is the path to the configuration properties file
-* \<USER> an (optional) user used to protect the Excel spreadsheet.
-    Will use a default if not provided, and "password" is provided.
-* \<PASSWORD> an (optional) password required to modify the Excel spreadsheet
 * \<JSON INPUT FILE> the path location to the JSON file created by "staff-retriever"
 * \<EXCEL OUTPUT FILE> the path location to create the Excel spreadsheet
 
 For example, using
 
 * \<CONFIG FILE> - "config.properties"
-* \<USER> - "Test User"
-* \<PASSWORD> - "abcd"
 * \<JSON INPUT FILE> - "persons.json"
 * \<EXCEL OUTPUT FILE> - "All Staff List New.xlsx"
 
 the command would be:
 
 ```
-> target/appassembler/bin/all-staff-list-builder --config config.properties --user "Test User" --password abcd --input persons.json --output "All Staff List New.xlsx"
+> target/appassembler/bin/all-staff-list-builder --config config.properties --input persons.json --output "All Staff List New.xlsx"
 ```
-
-### Excel User and Password
-
-The "--user" and "--password" arguments are used to set the
-"ReadOnly-Recommended" flag on the Excel spreadsheet. When set, any user opening
-the Excel spreadsheet will be shown a dialog indicating that the file is
-"reserved by" the name given in "--user", and given an option to either type
-in the password, or open the file read-only. Only users entering the password
-can modify the Excel spreadsheet.
-
-The "user" setting is essentially cosmetic -- it is shown in the dialog, and
-has no other effect.
-
-The Excel spreadsheet is protected in this way because when opened normally,
-Excel "locks" the file, preventing it from being updated. This is a problem for
-the cron job in "k8s-staffdirectory-ldap", which cannot replace the file if it
-open for modification. Therefore the Excel spreadsheet used on the LAN should
-always have the user and password set.
 
 ## Document Mappings
 

--- a/docker_config/staffdirectory-ldap/staff-list-excel.sh
+++ b/docker_config/staffdirectory-ldap/staff-list-excel.sh
@@ -9,8 +9,6 @@
 #    SMB_DIRECTORY - The Samba directory to upload the file to
 #    SMB_USER - the Samba username
 #    SMB_PASSWORD - the Samba password
-#    EXCEL_MODIFICATION_USER - The user to set on the Excel spreadsheet
-#    EXCEL_MODIFICATION_PASSWORD - The password to set on the Excel spreadsheet
 #    UPLOAD_EXCEL_FILENAME - The name of the uploaded file
 #    SMB_DO_UPLOAD - "true" if the upload should be performed. Any other value prevents upload
 
@@ -34,16 +32,6 @@ if [ -z "$SMB_PASSWORD" ]; then
   exit 1
 fi
 
-if [ -z "$EXCEL_MODIFICATION_USER" ]; then
-  echo "Please provide a non-empty 'EXCEL_MODIFICATION_USER' environment variable"
-  exit 1
-fi
-
-if [ -z "$EXCEL_MODIFICATION_PASSWORD" ]; then
-  echo "Please provide a non-empty 'EXCEL_MODIFICATION_PASSWORD' environment variable"
-  exit 1
-fi
-
 if [ -z "$UPLOAD_EXCEL_FILENAME" ]; then
   echo "Please provide a non-empty 'UPLOAD_EXCEL_FILENAME' environment variable"
   exit 1
@@ -55,7 +43,7 @@ JSON_FILE="$SCRIPT_DIR/output/persons.json"
 EXCEL_FILE="$SCRIPT_DIR/output/all-staff-list-new.xlsx"
 
 echo === Building Excel spreadsheet ===
-$SCRIPT_DIR/bin/all-staff-list-builder --user "$EXCEL_MODIFICATION_USER" --password "$EXCEL_MODIFICATION_PASSWORD" --config "$CONFIG_PROPERTIES_FILE" --input "$JSON_FILE" --output "$EXCEL_FILE"
+$SCRIPT_DIR/bin/all-staff-list-builder --config "$CONFIG_PROPERTIES_FILE" --input "$JSON_FILE" --output "$EXCEL_FILE"
 BUILD_RESULT=$?
 if (( $BUILD_RESULT != 0 )); then
   echo "ERROR: An error occurred running all-staff-list-builder."

--- a/src/main/java/edu/umd/lib/staffdir/AllStaffListBuilder.java
+++ b/src/main/java/edu/umd/lib/staffdir/AllStaffListBuilder.java
@@ -33,8 +33,6 @@ public class AllStaffListBuilder {
     String propFilename = cmdLine.getOptionValue("config");
     String inputFilename = cmdLine.getOptionValue("input");
     String outputFilename = cmdLine.getOptionValue("output");
-    String excelUser = cmdLine.getOptionValue("user");
-    String excelPassword = cmdLine.getOptionValue("password");
 
     Properties props = getProperties(propFilename);
 
@@ -50,7 +48,7 @@ public class AllStaffListBuilder {
     List<Map<String, String>> categoryStatusAbbreviations = sr.toMap(spreadsheetDocId, "CategoryStatus");
 
     ExcelGenerator excelGenerator = new ExcelGenerator(allStaffListMappings, categoryStatusAbbreviations);
-    excelGenerator.generate(outputFilename, jsonPersons, excelUser, excelPassword);
+    excelGenerator.generate(outputFilename, jsonPersons);
   }
 
   /**
@@ -145,16 +143,6 @@ public class AllStaffListBuilder {
         .required()
         .desc("The properties file for containing Google credentials")
         .build();
-    Option userOption = Option.builder("u")
-        .longOpt("user")
-        .hasArg()
-        .desc("The user to require to modify the Excel spreadsheet.")
-        .build();
-    Option passwordOption = Option.builder("p")
-        .longOpt("password")
-        .hasArg()
-        .desc("The password required to modify the Excel spreadsheet.")
-        .build();
     Option helpOption = Option.builder("h")
         .longOpt("help")
         .desc("Print this message")
@@ -164,8 +152,6 @@ public class AllStaffListBuilder {
     options.addOption(inputOption);
     options.addOption(outputOption);
     options.addOption(configOption);
-    options.addOption(userOption);
-    options.addOption(passwordOption);
     options.addOption(helpOption);
 
     return options;


### PR DESCRIPTION
Removed the code that sets the Excel "Read-Only Recommended"
functionality as it is not needed, replaced by setting the Samba file
permissions for the Excel spreadsheet to be "read only".

Removed the EXCEL_MODIFICATION_USER/EXCEL_MODIFICATION_PASSWORD
parameters from the
"docker_config/staffdirectory-ldap/staff-list-excel.sh" script.

Removed the explanatory sections from the README.md.

https://issues.umd.edu/browse/LIBITD-1984