### PR TITLE
LIBITD-2487. Fix Jenkinsfile for Jenkins v2.440.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
 
   environment {
     MAVEN_SETTINGS_XML = "--settings /apps/ci/maven-repository/settings.xml"
-    
+
     DEFAULT_RECIPIENTS = "${ \
       sh(returnStdout: true, \
          script: 'echo $JENKINS_DEFAULT_EMAIL_RECIPIENTS').trim() \
@@ -111,7 +111,9 @@ pipeline {
           junit '**/target/surefire-reports/*.xml'
 
           // Collect Checkstyle reports
-          recordIssues(tools: [checkStyle(reportEncoding: 'UTF-8')], unstableTotalAll: 1)
+          recordIssues(tools: [checkStyle(reportEncoding: 'UTF-8')],
+                       qualityGates: [[threshold: 1, type: 'TOTAL', criticality: 'UNSTABLE']]
+          )
         }
       }
     }
@@ -122,7 +124,7 @@ pipeline {
       emailext to: "$DEFAULT_RECIPIENTS",
                subject: "$EMAIL_SUBJECT",
                body: "$EMAIL_CONTENT"
-               
+
       // Clean the workspace
       cleanWs()
     }


### PR DESCRIPTION
Updated the "recordIssues" directive in the "Jenkinsfile" to use the "qualityGates" parameter, instead of the obsolete "unstableTotalAll" parameter.

https://umd-dit.atlassian.net/browse/LIBITD-2487